### PR TITLE
Register DetectionModel as safe global before loading YOLO

### DIFF
--- a/idle_metins.py
+++ b/idle_metins.py
@@ -32,6 +32,10 @@ def main(event, log_level, start, saved_credentials_idx):
 
 
 def run(event, log_level, start, saved_credentials_idx):
+    from torch.serialization import add_safe_globals
+    from ultralytics.nn.tasks import DetectionModel
+
+    add_safe_globals([DetectionModel])
     yolo = YOLO(MODELS_DIR / "valium_idle_metiny_yolov8s.pt").to("cuda:0")
     yolo_verbose = log_level in ["TRACE", "DEBUG"]
     logger.info("YOLO model loaded.")


### PR DESCRIPTION
## Summary
- register the ultralytics DetectionModel class with torch's safe globals prior to loading the YOLO checkpoint used by the idle bot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9450d7ca483309f74459e4e621908