### PR TITLE
Import Sequential for YOLO safe globals

### DIFF
--- a/idle_metins.py
+++ b/idle_metins.py
@@ -33,9 +33,10 @@ def main(event, log_level, start, saved_credentials_idx):
 
 def run(event, log_level, start, saved_credentials_idx):
     from torch.serialization import add_safe_globals
+    from torch.nn.modules.container import Sequential
     from ultralytics.nn.tasks import DetectionModel
 
-    add_safe_globals([DetectionModel])
+    add_safe_globals([DetectionModel, Sequential])
     yolo = YOLO(MODELS_DIR / "valium_idle_metiny_yolov8s.pt").to("cuda:0")
     yolo_verbose = log_level in ["TRACE", "DEBUG"]
     logger.info("YOLO model loaded.")


### PR DESCRIPTION
## Summary
- import `Sequential` inside `run` to match the YOLO model's serialized modules
- include `Sequential` in the `add_safe_globals` call so deserialization accepts YOLO weights

## Testing
- python idle_metins.py --log-level INFO --start 1 --saved_credentials_idx 1 *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c9478108d8833093cde73548bdfc35