### PR TITLE
Include BotBind in GUI enum tables

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -17,7 +17,7 @@ import dung_polana
 import fishbot
 import idle_metins
 import settings
-from settings import GameBind, UserBind
+from settings import BotBind, GameBind, UserBind
 from utils import setup_logger
 
 
@@ -295,7 +295,11 @@ class SettingsPanel(QtWidgets.QWidget):
         general_group.setLayout(general_form)
         layout.addWidget(general_group)
 
-        for enum_cls, title in ((GameBind, "GameBind"), (UserBind, "UserBind")):
+        for enum_cls, title in (
+            (GameBind, "GameBind"),
+            (UserBind, "UserBind"),
+            (BotBind, "BotBind"),
+        ):
             group = QtWidgets.QGroupBox(f"Bindy {title}")
             table = QtWidgets.QTableWidget(len(list(enum_cls)), 2)
             table.setHorizontalHeaderLabels(["Akcja", "Wartość"])


### PR DESCRIPTION
## Summary
- add BotBind import to the GUI settings panel
- extend the enum table construction loop to include BotBind

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c964b654408330be04666d5c119661