### PR TITLE
Make Tesseract and game paths configurable

### DIFF
--- a/game_controller.py
+++ b/game_controller.py
@@ -1,12 +1,12 @@
+import ntpath
 import os
 import re
+from pathlib import Path
 from random import choice, choices, uniform
 from time import perf_counter, sleep
 from typing import Generator, Optional, Tuple
 
 import pytesseract
-
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR/tesseract.exe"
 
 import cv2
 import numpy as np
@@ -21,7 +21,9 @@ from pynput.mouse import Listener as MouseListener
 
 import positions
 from settings import (
+    GAME_EXE_PATH,
     GAME_VIEW_POLY_OFF_BTN_POS,
+    TESSERACT_CMD,
     WINDOW_HEIGHT,
     WINDOW_NAME,
     WINDOW_WIDTH,
@@ -31,6 +33,9 @@ from settings import (
 )
 from utils import Success
 from vision_detector import VisionDetector
+
+
+pytesseract.pytesseract.tesseract_cmd = str(TESSERACT_CMD)
 
 
 def scale_img(img, scale=5):
@@ -71,7 +76,7 @@ class GameController:
         self.start_delay = start_delay
 
         self.saved_credentials_idx = saved_credentials_idx
-        self.game_exe_path = r"C:\BOT\ValiumAkademia\valium.exe"  # vm
+        self.game_exe_path = Path(GAME_EXE_PATH)
 
         self.keyboard = KeyboardController()
         self.keyboard_listener = self._init_keyboard_listener()
@@ -626,11 +631,13 @@ class GameController:
 
     def open_game(self, load_wait: float = 30):
         logger.info("Opening the game...")
-        game_dir = os.path.dirname(
-            self.game_exe_path
-        )  # Assumes the game's working directory is its location.
-        # Set the working directory to the game's directory and run as admin.
-        command = rf'Powershell -Command "&{{Set-Location -Path {game_dir}; Start-Process "{self.game_exe_path}" -Verb RunAs}}"'
+        game_path_str = str(self.game_exe_path)
+        game_dir = ntpath.dirname(game_path_str) or "."
+        command = (
+            'Powershell -Command '
+            f'"&{{Set-Location -Path \\"{game_dir}\\"; '
+            f'Start-Process \\"{game_path_str}\\" -Verb RunAs}}"'
+        )
         os.system(command)
         logger.debug(f"Waiting for the game to load... ({load_wait}s)")
         sleep(load_wait)  # wait for the game to load

--- a/gui_app.py
+++ b/gui_app.py
@@ -465,6 +465,8 @@ class SettingsPanel(QtWidgets.QWidget):
 
     def _is_directory_path(self, name: str, path_value: PurePath) -> bool:
         upper_name = name.upper()
+        if upper_name.endswith("_CMD"):
+            return False
         if upper_name.endswith(("_DIR", "_DIRS")):
             return True
         if upper_name.endswith(("_FILE", "_PATH", "_FPATH")):

--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,9 @@ METINS_DIR = TARGET_TEMPLATES_DIR / "metins"
 MODELS_DIR = PurePath("models")
 DATASETS_DIR = DATA_DIR / "datasets"
 
+TESSERACT_CMD = Path(r"C:\Program Files\Tesseract-OCR\tesseract.exe")
+GAME_EXE_PATH = Path(r"C:\BOT\ValiumAkademia\valium.exe")
+
 
 class GameBind(Enum):
     ATTACK = Key.space

--- a/vision_detector.py
+++ b/vision_detector.py
@@ -4,8 +4,6 @@ from typing import Tuple
 
 import pytesseract
 
-pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR/tesseract.exe'
-
 import cv2
 import numpy as np
 import win32con
@@ -20,6 +18,7 @@ from settings import (
     RUNO_LESNE_DROPPED_FPATH,
     TEMPLATE_BUTELKA_DYWIZJI_FPATH,
     TEMPLATE_VALIUM_MSG_FPATH,
+    TESSERACT_CMD,
     VISION_EFFECTS_BBOX,
     WINDOW_HEIGHT,
     WINDOW_NAME,
@@ -31,6 +30,9 @@ from settings import (
     WINDOW_NOT_FOUND_EXIT_DELAY,
 )
 import positions
+
+
+pytesseract.pytesseract.tesseract_cmd = str(TESSERACT_CMD)
 
 
 class WindowNotFoundError(ValueError):


### PR DESCRIPTION
## Summary
- add configurable `TESSERACT_CMD` and `GAME_EXE_PATH` paths to the shared settings module
- reuse the new settings in the game controller and vision detector instead of hardcoding paths
- expose the paths in the settings GUI and configuration file handling

## Testing
- python -m compileall settings.py game_controller.py vision_detector.py gui_app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9654bc6cc833099ae810a96306c5f