### PR TITLE
Make GUI expose advanced configuration and documentation

### DIFF
--- a/idle_metins.py
+++ b/idle_metins.py
@@ -31,7 +31,17 @@ def main(event, log_level, start, saved_credentials_idx):
     run(event, log_level, start, saved_credentials_idx)
 
 
-def run(event, log_level, start, saved_credentials_idx):
+def run(
+    event,
+    log_level,
+    start,
+    saved_credentials_idx,
+    yolo_confidence_threshold: float = 0.75,
+    channel_timeout: float = 20.0,
+    walk_to_metin_time: float = 1.25,
+    metin_destroy_time: float = 1.0,
+    looking_around_move_camera_press_time: float = 0.5,
+):
     yolo = YOLO(MODELS_DIR / "valium_idle_metiny_yolov8s.pt").to("cuda:0")
     yolo_verbose = log_level in ["TRACE", "DEBUG"]
     logger.info("YOLO model loaded.")
@@ -44,16 +54,16 @@ def run(event, log_level, start, saved_credentials_idx):
 
     channel_gen = channel_generator(1, 8, start=start, step=3 if event else 1)
 
-    YOLO_CONFIDENCE_THRESHOLD = 0.75
-    CHANNEL_TIMEOUT = 20
-    LOOKING_AROUND_MOVE_CAMERA_PRESS_TIME = 0.5
-    WALK_TO_METIN_TIME = 1.25
+    YOLO_CONFIDENCE_THRESHOLD = float(yolo_confidence_threshold)
+    CHANNEL_TIMEOUT = float(channel_timeout)
+    LOOKING_AROUND_MOVE_CAMERA_PRESS_TIME = float(looking_around_move_camera_press_time)
+    WALK_TO_METIN_TIME = float(walk_to_metin_time)
 
     # METIN_CLS = 0  # smierci sohan
     # METIN_DESTROY_TIME = 8  # smierci sohan | poly + masne eq + IS
 
     METIN_CLS = 1  # upadku polana
-    METIN_DESTROY_TIME = 1  # upadku polana | poly + masne eq + IS
+    METIN_DESTROY_TIME = float(metin_destroy_time)  # upadku polana | poly + masne eq + IS
 
     assert isinstance(METIN_CLS, int), "METIN_CLS must be an integer."
 


### PR DESCRIPTION
## Summary
- parameterize the dungeon, idle metins and fishbot routines so that YOLO thresholds, timeouts and other timings can be supplied by the GUI
- redesign BotControlWidget to surface help text, editable labels/titles and persist these overrides together with new configuration inputs for every mode
- enhance the GUI with instructions, save/reset buttons and config.json persistence while keeping settings.json handling compatible

## Testing
- python -m py_compile gui_app.py dung_polana.py idle_metins.py fishbot.py

------
https://chatgpt.com/codex/tasks/task_e_68c95aaee9388330af10cc84f083716a