### PR TITLE
Add teleport panel automation and GUI configuration

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,68 @@
+"""Utilities for loading and saving shared configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from loguru import logger
+
+CONFIG_FILE = Path("config.json")
+DEFAULT_TELEPORT_SEQUENCE: List[int] = list(range(1, 9))
+
+
+def load_config() -> Dict[str, Any]:
+    """Load the full configuration file.
+
+    Returns an empty dictionary if the file does not exist or contains
+    invalid JSON. The function logs a warning when the JSON cannot be
+    decoded.
+    """
+
+    if not CONFIG_FILE.exists():
+        return {}
+    try:
+        return json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.warning("Nie udało się wczytać pliku %s: %s", CONFIG_FILE, exc)
+        return {}
+
+
+def save_config(data: Dict[str, Any]) -> None:
+    """Persist *data* to :data:`CONFIG_FILE`."""
+
+    CONFIG_FILE.write_text(
+        json.dumps(data, indent=4, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def load_teleport_sequence(config: Dict[str, Any] | None = None) -> List[int]:
+    """Return the configured teleport sequence.
+
+    Falls back to :data:`DEFAULT_TELEPORT_SEQUENCE` if no custom sequence is
+    defined. Invalid entries (non-integer values or indices outside the
+    1..8 range) are ignored.
+    """
+
+    data = config if config is not None else load_config()
+    teleport_config = data.get("teleport", {})
+    raw_sequence = teleport_config.get("sequence")
+    if not isinstance(raw_sequence, list):
+        return DEFAULT_TELEPORT_SEQUENCE.copy()
+
+    cleaned: List[int] = []
+    for value in raw_sequence:
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            logger.debug("Pomijam niepoprawną pozycję teleportu: %r", value)
+            continue
+        if not 1 <= index <= 8:
+            logger.debug("Pomijam pozycję teleportu poza zakresem 1..8: %s", index)
+            continue
+        if index not in cleaned:
+            cleaned.append(index)
+    if not cleaned:
+        return DEFAULT_TELEPORT_SEQUENCE.copy()
+    return cleaned

--- a/game_controller.py
+++ b/game_controller.py
@@ -96,6 +96,7 @@ class GameController:
         self.minimap_visible = True
         self.map_visible = False
         self.settings_visible = False
+        self.teleport_panel_visible = False
 
         self._start_delay(self.start_delay)
         self._activate_window()
@@ -120,6 +121,7 @@ class GameController:
         self.minimap_visible = True
         self.map_visible = False
         self.settings_visible = False
+        self.teleport_panel_visible = False
 
     def _activate_window(self):
         # dummy function to activate the window by clicking on it in safe area
@@ -661,6 +663,50 @@ class GameController:
         logger.info("Showing the map...")
         if not self.map_visible:
             self.toggle_map()
+
+    def open_teleport_panel(self):
+        if self.teleport_panel_visible:
+            logger.debug("Teleport panel already open.")
+            return
+        logger.info("Opening teleport panel (F9)...")
+        self.tap_key(Key.f9, press_time=0.3)
+        sleep(0.5)
+        self.teleport_panel_visible = True
+
+    def close_teleport_panel(self):
+        if not self.teleport_panel_visible:
+            logger.debug("Teleport panel already closed.")
+            return
+        logger.debug("Closing teleport panel (F9)...")
+        self.tap_key(Key.f9, press_time=0.3)
+        sleep(0.3)
+        self.teleport_panel_visible = False
+
+    def teleport_to_position(
+        self,
+        index: int,
+        after_tp_wait: float = 10.0,
+        close_panel: bool = True,
+    ):
+        logger.info(f"Teleporting to preset {index}...")
+        try:
+            slot_center = positions.TELEPORT_PANEL_SLOT_CENTERS[index]
+        except KeyError as exc:
+            raise ValueError(f"Unknown teleport preset index: {index}") from exc
+
+        self.open_teleport_panel()
+        global_slot_center = self.vision_detector.get_global_pos(slot_center)
+        self.click_at(global_slot_center)
+
+        if close_panel:
+            self.close_teleport_panel()
+
+        logger.debug(
+            "Waiting for the teleportation to finish... (%ss)",
+            after_tp_wait,
+        )
+        sleep(after_tp_wait)
+        self.teleport_panel_visible = False
 
     def teleport_to_polana(self, after_tp_wait: float = 10):
         logger.info("Teleporting to Leśna Polana...")

--- a/positions.py
+++ b/positions.py
@@ -25,6 +25,18 @@ LOAD_CREDENTIAL_BTN_SPACING = 40
 # map (tab)
 MAP_POLANA_BTN_CENTER = (460, 437)
 
+# teleport panel (F9)
+TELEPORT_PANEL_SLOT_CENTERS = {
+    1: (310, 210),
+    2: (375, 210),
+    3: (440, 210),
+    4: (505, 210),
+    5: (310, 275),
+    6: (375, 275),
+    7: (440, 275),
+    8: (505, 275),
+}
+
 # settings buttons
 GAME_SYS_SETTINGS_BTN_CENTER = (400, 240)
 GSS_CAM_CLOSER_BTN_CENTER = (395, 315)


### PR DESCRIPTION
## Summary
- add coordinate definitions for F9 teleport slots and introduce a shared config manager
- extend the game controller and idle metins workflow to open the teleport panel and jump through configured presets
- enhance the GUI with a teleport configuration tab that persists the preset order and activation to config.json

## Testing
- python -m compileall positions.py game_controller.py idle_metins.py gui_app.py config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68ca960d39008330b520aef35c24ca0a