### PR TITLE
Preserve restart stage prompt state

### DIFF
--- a/wukong.py
+++ b/wukong.py
@@ -380,7 +380,7 @@ def _monitor_stage(
     if not prompt_already_confirmed:
         _wait_for_stage_prompt(vision, stage, timeout)
 
-    prompt_seen = False
+    prompt_seen = prompt_already_confirmed
     last_progress: Optional[int] = None
     last_message = ""
 


### PR DESCRIPTION
## Summary
- carry the already-confirmed prompt state into stage monitoring so restart completion messages are handled immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbce3171108330bd7d2ea9d9754d41