### PR TITLE
Align WuKong YOLO classes with model labels

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -75,6 +75,8 @@ class ResourceName(Enum):
     WUKONG_MOB = "wukong_mob"
     WUKONG_CRIMSON_GOURD = "wukong_crimson_gourd"
     WUKONG_MONKEY_KING = "wukong_monkey_king"
+    WUKONG_CLOUD_GUARDIAN = "wukong_cloud_guardian"
+    WUKONG_FLAMING_PHOENIX = "wukong_flaming_phoenix"
 
 
 # WINDOW_NAME = "Akademia Valium.pl"


### PR DESCRIPTION
## Summary
- extend `ResourceName` with Cloud Guardian and Flaming Phoenix handles so the automation can refer to all WuKong bosses
- map WuKong YOLO resources to the Polish class names exported by `models/wukong.pt`
- hook the Cloud Guardian and Flaming Phoenix stages into the shared detector helpers for consistent YOLO-based tracking

## Testing
- python -m compileall wukong.py settings.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf28f5d04833099dac49502c9cf6b