### PR TITLE
Ensure WuKong combat reasserts attack key

### DIFF
--- a/game_controller.py
+++ b/game_controller.py
@@ -342,8 +342,10 @@ class GameController:
         self.toggle_skill(UserBind.BERSERK, reset_animation=reset_animation)
         self.toggle_skill(UserBind.AURA, reset_animation=reset_animation)
 
-    def start_attack(self):
-        if not self.attacking:
+    def start_attack(self, *, force: bool = False):
+        """Hold the basic attack key until :meth:`stop_attack` is called."""
+
+        if force or not self.attacking:
             self.press_key(GameBind.ATTACK)
             self.attacking = True
 


### PR DESCRIPTION
## Summary
- allow `GameController.start_attack` to optionally re-send the attack key press even if it is already marked as held
- make the WuKong combat loop periodically force the attack key press just like `dung_polana.py` so stray releases do not stop attacking

## Testing
- python -m compileall wukong.py game_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3495774c8330bb595a0d1991ee0d