### PR TITLE
Switch WuKong stage completion to detection

### DIFF
--- a/wukong.py
+++ b/wukong.py
@@ -115,6 +115,7 @@ DETECTION_METHOD_UNAVAILABLE = "unavailable"
 
 REMAINING_PATTERN = re.compile(r"pozostał[oa]?\s*:?\s*(\d+)")
 PROMPT_WAIT_LIMIT = 15.0
+CLOAK_REFRESH_INTERVAL = 45.0
 
 DEFAULT_STAGE_TIMEOUTS: Tuple[float, ...] = (
     90,
@@ -276,6 +277,8 @@ class WuKongAutomation:
         )
 
         self._buffs_initialized = False
+        self._cloak_initialized = False
+        self._last_cloak_activation = 0.0
         self._yolo_model: YOLO | None = None
         self._yolo_class_ids: Dict[ResourceName, int] = {}
 
@@ -880,6 +883,20 @@ class WuKongAutomation:
         self.game.toggle_passive_skills(reset_animation=False)
         self._buffs_initialized = True
 
+    def _ensure_cloak_active(self, now: float) -> None:
+        if not self._cloak_initialized or now - self._last_cloak_activation >= CLOAK_REFRESH_INTERVAL:
+            if not self._cloak_initialized:
+                logger.info(
+                    "Aktywuję pelerynę (F4), aby przyciągać przeciwników przez całą wyprawę."
+                )
+            else:
+                logger.debug(
+                    "Odświeżam działanie peleryny (F4), aby utrzymać efekt przez całą wyprawę."
+                )
+            self.game.tap_key(UserBind.MARMUREK)
+            self._cloak_initialized = True
+            self._last_cloak_activation = now
+
     def _make_basic_combat_action(
         self,
         *,
@@ -978,7 +995,14 @@ class WuKongAutomation:
         threshold: float = 0.82,
         interval: float = 4.0,
     ) -> Callable[[float], None]:
-        state = {"last_check": 0.0, "present": None, "missing_logged": False}
+        state = {
+            "last_check": 0.0,
+            "present": None,
+            "missing_logged": False,
+            "absent_since": None,
+            "completion_grace": 3.0,
+            "detection_available": True,
+        }
 
         def _callback(now: float) -> None:
             if now - state["last_check"] < interval:
@@ -998,6 +1022,9 @@ class WuKongAutomation:
                         resource.value,
                     )
                     state["missing_logged"] = True
+                state["detection_available"] = False
+                state["present"] = None
+                state["absent_since"] = None
                 state["last_check"] = now
                 return
 
@@ -1006,6 +1033,7 @@ class WuKongAutomation:
                 state["last_check"] = now
                 return
 
+            state["detection_available"] = True
             present = bool(detection.positions)
             method_verbose = self._detection_method_verbose_label(method)
 
@@ -1023,8 +1051,34 @@ class WuKongAutomation:
                 else:
                     logger.success("%s nie są już wykrywane (%s).", label.capitalize(), method_verbose)
 
+            if present:
+                state["absent_since"] = None
+            elif state["present"] is True or state["absent_since"] is None:
+                state["absent_since"] = now
+
             state["present"] = present
             state["last_check"] = now
+
+        def _completion_reason(now: float) -> Optional[str]:
+            if not state["detection_available"]:
+                return None
+            absent_since = state["absent_since"]
+            if absent_since is None:
+                return None
+            if now - absent_since >= state["completion_grace"]:
+                return f"Detekcja nie wykrywa już {label}."
+            return None
+
+        def _set_completion_grace(seconds: float) -> None:
+            state["completion_grace"] = max(0.0, seconds)
+
+        def _is_detection_available() -> bool:
+            return state["detection_available"]
+
+        _callback.completion_reason = _completion_reason  # type: ignore[attr-defined]
+        _callback.set_completion_grace = _set_completion_grace  # type: ignore[attr-defined]
+        _callback.detection_available = _is_detection_available  # type: ignore[attr-defined]
+        _callback.state = state  # type: ignore[attr-defined]
 
         return _callback
 
@@ -1036,7 +1090,15 @@ class WuKongAutomation:
         threshold: float = 0.82,
         interval: float = 4.0,
     ) -> Callable[[float], None]:
-        state = {"last_check": 0.0, "count": None, "missing_logged": False}
+        state = {
+            "last_check": 0.0,
+            "count": None,
+            "missing_logged": False,
+            "target_count": 0,
+            "cleared_since": None,
+            "completion_grace": 3.0,
+            "detection_available": True,
+        }
 
         def _callback(now: float) -> None:
             if now - state["last_check"] < interval:
@@ -1056,6 +1118,8 @@ class WuKongAutomation:
                         resource.value,
                     )
                     state["missing_logged"] = True
+                state["detection_available"] = False
+                state["cleared_since"] = None
                 state["last_check"] = now
                 return
 
@@ -1064,6 +1128,7 @@ class WuKongAutomation:
                 state["last_check"] = now
                 return
 
+            state["detection_available"] = True
             count = len(detection.positions)
             method_verbose = self._detection_method_verbose_label(method)
 
@@ -1093,8 +1158,45 @@ class WuKongAutomation:
                         method_verbose,
                     )
 
+            if count <= state["target_count"]:
+                if state["cleared_since"] is None:
+                    state["cleared_since"] = now
+            else:
+                state["cleared_since"] = None
+
             state["count"] = count
             state["last_check"] = now
+
+        def _set_completion_target(target: int) -> None:
+            state["target_count"] = target
+            if state["count"] is not None and state["count"] > target:
+                state["cleared_since"] = None
+
+        def _set_completion_grace(seconds: float) -> None:
+            state["completion_grace"] = max(0.0, seconds)
+
+        def _completion_reason(now: float) -> Optional[str]:
+            if not state["detection_available"]:
+                return None
+            cleared_since = state["cleared_since"]
+            if cleared_since is None:
+                return None
+            if now - cleared_since >= state["completion_grace"]:
+                if state["target_count"] > 0:
+                    return (
+                        f"Detekcja potwierdza osiągnięcie limitu {label} (<= {state['target_count']})."
+                    )
+                return f"Detekcja potwierdza brak {label}."
+            return None
+
+        def _is_detection_available() -> bool:
+            return state["detection_available"]
+
+        _callback.set_completion_target = _set_completion_target  # type: ignore[attr-defined]
+        _callback.set_completion_grace = _set_completion_grace  # type: ignore[attr-defined]
+        _callback.completion_reason = _completion_reason  # type: ignore[attr-defined]
+        _callback.detection_available = _is_detection_available  # type: ignore[attr-defined]
+        _callback.state = state  # type: ignore[attr-defined]
 
         return _callback
 
@@ -1107,14 +1209,17 @@ class WuKongAutomation:
         progress_parser: Optional[Callable[[str], Optional[int]]] = None,
         completion_keywords: Optional[Sequence[str]] = None,
         prompt_already_confirmed: bool = False,
+        completion_check: Optional[Callable[[float], Optional[str]]] = None,
     ) -> float:
         stage_start = perf_counter()
         if not prompt_already_confirmed:
             self._wait_for_stage_prompt(stage, timeout)
 
         prompt_seen = prompt_already_confirmed
+        prompt_confirmed_via_keywords = prompt_already_confirmed
         last_progress: Optional[int] = None
         last_message = ""
+        current_prompt_message: Optional[str] = None
 
         while True:
             now = perf_counter()
@@ -1123,8 +1228,21 @@ class WuKongAutomation:
                     f"Etap '{stage.title}' przekroczył limit {timeout:.0f}s."
                 )
 
+            self._ensure_cloak_active(now)
+
             if action_callback is not None:
                 action_callback(now)
+
+            if completion_check is not None:
+                completion_message = completion_check(now)
+                if completion_message:
+                    logger.info(completion_message)
+                    logger.debug(
+                        "Ukończono etap na podstawie detekcji obiektów (bez analizy komunikatów)."
+                    )
+                    elapsed = now - stage_start
+                    logger.success("Etap '%s' ukończony w %.1fs.", stage.title, elapsed)
+                    return elapsed
 
             message = self._capture_dungeon_message()
             if message:
@@ -1132,18 +1250,48 @@ class WuKongAutomation:
                     logger.debug("Komunikat lochów: %s", message)
                     last_message = message
 
-                if self._message_contains_keywords(message, stage.prompt_keywords):
+                matches_prompt_keywords = self._message_contains_keywords(
+                    message, stage.prompt_keywords
+                )
+
+                if matches_prompt_keywords:
+                    if not prompt_confirmed_via_keywords and not prompt_already_confirmed:
+                        logger.debug(
+                            "Potwierdzono komunikat etapu na podstawie słów kluczowych."
+                        )
                     prompt_seen = True
+                    prompt_confirmed_via_keywords = True
+                    if current_prompt_message != message:
+                        current_prompt_message = message
                     if progress_parser is not None:
                         remaining = progress_parser(message)
                         if remaining is not None and remaining != last_progress:
                             logger.info("Pozostało: %s", remaining)
                             last_progress = remaining
-                elif prompt_seen:
-                    if completion_keywords and self._message_contains_keywords(message, completion_keywords):
+                elif current_prompt_message is None:
+                    current_prompt_message = message
+                    prompt_seen = True
+                    if not prompt_confirmed_via_keywords:
+                        logger.debug(
+                            "Zapamiętano początkowy komunikat etapu bez dopasowania słów kluczowych: %s",
+                            message,
+                        )
+
+                if (
+                    prompt_seen
+                    and current_prompt_message is not None
+                    and message != current_prompt_message
+                ):
+                    if completion_keywords and self._message_contains_keywords(
+                        message, completion_keywords
+                    ):
                         logger.info("Wykryto komunikat kolejnego etapu: %s", message)
                     else:
                         logger.info("Komunikat etapu uległ zmianie: %s", message)
+                        if not prompt_confirmed_via_keywords:
+                            logger.debug(
+                                "Ukończono etap na podstawie zmiany komunikatu (ścieżka awaryjna)."
+                            )
                     elapsed = now - stage_start
                     logger.success("Etap '%s' ukończony w %.1fs.", stage.title, elapsed)
                     return elapsed
@@ -1250,6 +1398,7 @@ class WuKongAutomation:
         extra_callbacks: Optional[Sequence[Callable[[float], None]]] = None,
         progress_parser: Optional[Callable[[str], Optional[int]]] = None,
         prompt_confirmed: bool = False,
+        completion_check: Optional[Callable[[float], Optional[str]]] = None,
     ) -> float:
         self._prepare_for_combat()
         self.game.start_attack()
@@ -1268,6 +1417,7 @@ class WuKongAutomation:
                 completion_keywords=stage.completion_keywords,
                 progress_parser=progress_parser,
                 prompt_already_confirmed=prompt_confirmed,
+                completion_check=completion_check,
             )
         finally:
             self.game.stop_attack()
@@ -1327,6 +1477,11 @@ class WuKongAutomation:
     # ------------------------------------------------------------------
 
     def _handle_slay_first_wave(self, stage: StageDefinition, timeout: float) -> float:
+        mob_tracker = self._make_template_presence_callback(
+            ResourceName.WUKONG_MOB,
+            label="przeciwników WuKonga",
+        )
+        mob_tracker.set_completion_grace(5.0)
         mob_engage = self._make_engage_callback(
             ResourceName.WUKONG_MOB,
             label="przeciwników WuKonga",
@@ -1336,8 +1491,9 @@ class WuKongAutomation:
             timeout,
             attack_interval=0.8,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
-            extra_callbacks=(mob_engage,),
+            extra_callbacks=(mob_tracker, mob_engage),
             progress_parser=self._extract_remaining_count,
+            completion_check=mob_tracker.completion_reason,
         )
 
     def _handle_destroy_first_metins(self, stage: StageDefinition, timeout: float) -> float:
@@ -1349,6 +1505,8 @@ class WuKongAutomation:
             ResourceName.WUKONG_METIN,
             label="kamieni Metin WuKonga",
         )
+        metin_tracker.set_completion_target(0)
+        metin_tracker.set_completion_grace(4.0)
         metin_engage = self._make_engage_callback(
             ResourceName.WUKONG_METIN,
             label="kamieni Metin WuKonga",
@@ -1360,6 +1518,7 @@ class WuKongAutomation:
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(metin_tracker, metin_engage),
             progress_parser=self._extract_remaining_count,
+            completion_check=metin_tracker.completion_reason,
         )
 
     def _handle_clear_second_wave(self, stage: StageDefinition, timeout: float) -> float:
@@ -1371,6 +1530,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_MOB,
             label="mobów drugiej fali WuKonga",
         )
+        mob_tracker.set_completion_grace(5.0)
         mob_engage = self._make_engage_callback(
             ResourceName.WUKONG_MOB,
             label="mobów drugiej fali WuKonga",
@@ -1381,6 +1541,7 @@ class WuKongAutomation:
             attack_interval=0.8,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(mob_tracker, mob_engage),
+            completion_check=mob_tracker.completion_reason,
         )
 
     def _handle_defeat_cloud_guardian(self, stage: StageDefinition, timeout: float) -> float:
@@ -1392,6 +1553,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_CLOUD_GUARDIAN,
             label="Obrońcę Chmur WuKonga",
         )
+        guardian_tracker.set_completion_grace(5.0)
         guardian_engage = self._make_engage_callback(
             ResourceName.WUKONG_CLOUD_GUARDIAN,
             label="Obrońcę Chmur WuKonga",
@@ -1402,6 +1564,7 @@ class WuKongAutomation:
             attack_interval=0.7,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(guardian_tracker, guardian_engage),
+            completion_check=guardian_tracker.completion_reason,
         )
 
     def _handle_place_phoenix_eggs(self, stage: StageDefinition, timeout: float) -> float:
@@ -1413,6 +1576,12 @@ class WuKongAutomation:
             self._use_phoenix_eggs()
             last_egg_usage["time"] = now
 
+        egg_tracker = self._make_template_count_callback(
+            ResourceName.WUKONG_PHOENIX_EGG,
+            label="jaj Feniksa WuKonga",
+        )
+        egg_tracker.set_completion_target(0)
+        egg_tracker.set_completion_grace(4.0)
         mob_engage = self._make_engage_callback(
             ResourceName.WUKONG_MOB,
             label="przeciwników WuKonga",
@@ -1422,11 +1591,18 @@ class WuKongAutomation:
             timeout,
             attack_interval=0.8,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
-            extra_callbacks=(_egg_callback, mob_engage),
+            extra_callbacks=(_egg_callback, egg_tracker, mob_engage),
             progress_parser=self._extract_remaining_count,
+            completion_check=egg_tracker.completion_reason,
         )
 
     def _handle_destroy_phoenix_eggs(self, stage: StageDefinition, timeout: float) -> float:
+        egg_tracker = self._make_template_count_callback(
+            ResourceName.WUKONG_PHOENIX_EGG,
+            label="jaj Feniksa WuKonga",
+        )
+        egg_tracker.set_completion_target(0)
+        egg_tracker.set_completion_grace(4.0)
         egg_engage = self._make_engage_callback(
             ResourceName.WUKONG_PHOENIX_EGG,
             label="jaj Feniksa WuKonga",
@@ -1440,13 +1616,14 @@ class WuKongAutomation:
             timeout,
             attack_interval=0.75,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
-            extra_callbacks=(egg_engage, mob_engage),
+            extra_callbacks=(egg_tracker, egg_engage, mob_engage),
             progress_parser=self._extract_remaining_count,
+            completion_check=egg_tracker.completion_reason,
         )
 
     def _handle_repel_three_waves(self, stage: StageDefinition, timeout: float) -> float:
-        logger.info("Aktywuję pelerynę (F4), aby przyspieszyć pojawianie się fal.")
-        self.game.tap_key(UserBind.MARMUREK)
+        logger.debug("Potwierdzam aktywną pelerynę (F4) przed rozpoczęciem fal.")
+        self._ensure_cloak_active(perf_counter())
 
         self._confirm_template_presence(
             ResourceName.WUKONG_MOB,
@@ -1456,6 +1633,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_MOB,
             label="przeciwników w falach WuKonga",
         )
+        mob_tracker.set_completion_grace(6.0)
         mob_engage = self._make_engage_callback(
             ResourceName.WUKONG_MOB,
             label="przeciwników w falach WuKonga",
@@ -1468,6 +1646,7 @@ class WuKongAutomation:
             lure_interval=25.0,
             progress_parser=self._extract_remaining_count,
             extra_callbacks=(mob_tracker, mob_engage),
+            completion_check=mob_tracker.completion_reason,
         )
 
     def _handle_destroy_second_metin(self, stage: StageDefinition, timeout: float) -> float:
@@ -1479,6 +1658,8 @@ class WuKongAutomation:
             ResourceName.WUKONG_METIN,
             label="kamieni Metin WuKonga",
         )
+        metin_tracker.set_completion_target(0)
+        metin_tracker.set_completion_grace(4.0)
         metin_engage = self._make_engage_callback(
             ResourceName.WUKONG_METIN,
             label="kamieni Metin WuKonga",
@@ -1490,6 +1671,7 @@ class WuKongAutomation:
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             progress_parser=self._extract_remaining_count,
             extra_callbacks=(metin_tracker, metin_engage),
+            completion_check=metin_tracker.completion_reason,
         )
 
     def _handle_defeat_flaming_phoenix(self, stage: StageDefinition, timeout: float) -> float:
@@ -1501,6 +1683,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_FLAMING_PHOENIX,
             label="Płomiennego Feniksa WuKonga",
         )
+        phoenix_tracker.set_completion_grace(5.0)
         phoenix_engage = self._make_engage_callback(
             ResourceName.WUKONG_FLAMING_PHOENIX,
             label="Płomiennego Feniksa WuKonga",
@@ -1511,6 +1694,7 @@ class WuKongAutomation:
             attack_interval=0.7,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(phoenix_tracker, phoenix_engage),
+            completion_check=phoenix_tracker.completion_reason,
         )
 
     def _handle_clear_final_wave(self, stage: StageDefinition, timeout: float) -> float:
@@ -1522,6 +1706,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_MOB,
             label="ostatnich przeciwników WuKonga",
         )
+        mob_tracker.set_completion_grace(5.0)
         mob_engage = self._make_engage_callback(
             ResourceName.WUKONG_MOB,
             label="ostatnich przeciwników WuKonga",
@@ -1532,6 +1717,7 @@ class WuKongAutomation:
             attack_interval=0.8,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(mob_tracker, mob_engage),
+            completion_check=mob_tracker.completion_reason,
         )
 
     def _handle_destroy_crimson_gourds(self, stage: StageDefinition, timeout: float) -> float:
@@ -1543,6 +1729,8 @@ class WuKongAutomation:
             ResourceName.WUKONG_CRIMSON_GOURD,
             label="Karmazynowych Gurd",
         )
+        gourd_tracker.set_completion_target(0)
+        gourd_tracker.set_completion_grace(4.0)
         gourd_engage = self._make_engage_callback(
             ResourceName.WUKONG_CRIMSON_GOURD,
             label="Karmazynowych Gurd",
@@ -1554,6 +1742,7 @@ class WuKongAutomation:
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             progress_parser=self._extract_remaining_count,
             extra_callbacks=(gourd_tracker, gourd_engage),
+            completion_check=gourd_tracker.completion_reason,
         )
 
     def _handle_defeat_wukong(self, stage: StageDefinition, timeout: float) -> float:
@@ -1565,6 +1754,7 @@ class WuKongAutomation:
             ResourceName.WUKONG_MONKEY_KING,
             label="Małpiego Króla WuKonga",
         )
+        boss_tracker.set_completion_grace(5.0)
         boss_engage = self._make_engage_callback(
             ResourceName.WUKONG_MONKEY_KING,
             label="Małpiego Króla WuKonga",
@@ -1575,6 +1765,7 @@ class WuKongAutomation:
             attack_interval=0.65,
             skill_cooldowns=DEFAULT_SKILL_COOLDOWNS,
             extra_callbacks=(boss_tracker, boss_engage),
+            completion_check=boss_tracker.completion_reason,
         )
 
     def _handle_restart_expedition(self, stage: StageDefinition, timeout: float) -> float:


### PR DESCRIPTION
## Summary
- expose absence tracking and detection-based completion reasons from the WuKong template monitor callbacks
- let stage monitoring finish once the registered detection monitor reports completion instead of waiting for prompt swaps
- wire detection monitors and completion checks into each combat stage so progress is based on object detection instead of dungeon messages

## Testing
- python -m compileall wukong.py

------
https://chatgpt.com/codex/tasks/task_e_68cd49e1dab88330b0dc66d5a52b50af